### PR TITLE
Octogonz/add peer deps

### DIFF
--- a/apps/my-app/.eslintrc.json
+++ b/apps/my-app/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["react-app"]
+  "extends": ["eslint-config-react-app"]
 }

--- a/apps/my-app/package.json
+++ b/apps/my-app/package.json
@@ -37,6 +37,18 @@
     ]
   },
   "devDependencies": {
-    "eslint": "^7.16.0"
+    "eslint": "^7.16.0",
+    "eslint-config-react-app": "^6.0.0",
+
+    "@typescript-eslint/eslint-plugin": "^4.0.0",
+    "@typescript-eslint/parser": "^4.0.0",
+    "babel-eslint": "^10.0.0",
+    "eslint-plugin-flowtype": "^5.2.0",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jest": "^24.0.0",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-react": "^7.20.3",
+    "eslint-plugin-react-hooks": "^4.0.8",
+    "eslint-plugin-testing-library": "^3.9.0"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,7 +3,18 @@ dependencies:
   '@testing-library/jest-dom': 5.11.8
   '@testing-library/react': 11.2.2_react-dom@17.0.1+react@17.0.1
   '@testing-library/user-event': 12.6.0
+  '@typescript-eslint/eslint-plugin': 4.11.1_3692d19b2b43c496fd911cf1517291c7
+  '@typescript-eslint/parser': 4.11.1_eslint@7.16.0
+  babel-eslint: 10.1.0_eslint@7.16.0
   eslint: 7.16.0
+  eslint-config-react-app: 6.0.0_0fdcdfba755e295f3354cb116bdbf5c1
+  eslint-plugin-flowtype: 5.2.0_eslint@7.16.0
+  eslint-plugin-import: 2.22.1_eslint@7.16.0
+  eslint-plugin-jest: 24.1.3_eslint@7.16.0
+  eslint-plugin-jsx-a11y: 6.4.1_eslint@7.16.0
+  eslint-plugin-react: 7.22.0_eslint@7.16.0
+  eslint-plugin-react-hooks: 4.2.0_eslint@7.16.0
+  eslint-plugin-testing-library: 3.10.1_eslint@7.16.0
   react: 17.0.1
   react-dom: 17.0.1_react@17.0.1
   react-scripts: 4.0.1
@@ -2007,7 +2018,7 @@ packages:
       eslint: 7.16.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.1.0
-      semver: 7.3.2
+      semver: 7.3.4
       tsutils: 3.17.1
     dev: false
     engines:
@@ -2099,7 +2110,7 @@ packages:
       glob: 7.1.6
       is-glob: 4.0.1
       lodash: 4.17.20
-      semver: 7.3.2
+      semver: 7.3.4
       tsutils: 3.17.1
     dev: false
     engines:
@@ -2119,7 +2130,7 @@ packages:
       globby: 11.0.1
       is-glob: 4.0.1
       lodash: 4.17.20
-      semver: 7.3.2
+      semver: 7.3.4
       tsutils: 3.17.1
     dev: false
     engines:
@@ -2693,7 +2704,7 @@ packages:
       '@babel/types': 7.12.12
       eslint: 7.16.0
       eslint-visitor-keys: 1.3.0
-      resolve: 1.18.1
+      resolve: 1.19.0
     dev: false
     engines:
       node: '>=6'
@@ -4694,7 +4705,7 @@ packages:
   /eslint-import-resolver-node/0.3.4:
     dependencies:
       debug: 2.6.9
-      resolve: 1.18.1
+      resolve: 1.19.0
     dev: false
     resolution:
       integrity: sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -4733,7 +4744,7 @@ packages:
       minimatch: 3.0.4
       object.values: 1.1.2
       read-pkg-up: 2.0.0
-      resolve: 1.18.1
+      resolve: 1.19.0
       tsconfig-paths: 3.9.0
     dev: false
     engines:
@@ -4796,7 +4807,7 @@ packages:
       object.fromentries: 2.0.3
       object.values: 1.1.2
       prop-types: 15.7.2
-      resolve: 1.18.1
+      resolve: 1.19.0
       string.prototype.matchall: 4.0.3
     dev: false
     engines:
@@ -4905,7 +4916,7 @@ packages:
       optionator: 0.9.1
       progress: 2.0.3
       regexpp: 3.1.0
-      semver: 7.3.2
+      semver: 7.3.4
       strip-ansi: 6.0.0
       strip-json-comments: 3.1.1
       table: 6.0.4
@@ -7927,7 +7938,7 @@ packages:
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.8
-      resolve: 1.18.1
+      resolve: 1.19.0
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: false
@@ -10010,6 +10021,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
+  /resolve/1.19.0:
+    dependencies:
+      is-core-module: 2.2.0
+      path-parse: 1.0.6
+    dev: false
+    resolution:
+      integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
   /ret/0.1.15:
     dev: false
     engines:
@@ -10271,6 +10289,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+  /semver/7.3.4:
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+    engines:
+      node: '>=10'
+    hasBin: true
+    resolution:
+      integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
   /send/0.17.1:
     dependencies:
       debug: 2.6.9
@@ -12149,7 +12176,18 @@ packages:
       '@testing-library/jest-dom': 5.11.8
       '@testing-library/react': 11.2.2_react-dom@17.0.1+react@17.0.1
       '@testing-library/user-event': 12.6.0
+      '@typescript-eslint/eslint-plugin': 4.11.1_3692d19b2b43c496fd911cf1517291c7
+      '@typescript-eslint/parser': 4.11.1_eslint@7.16.0
+      babel-eslint: 10.1.0_eslint@7.16.0
       eslint: 7.16.0
+      eslint-config-react-app: 6.0.0_0fdcdfba755e295f3354cb116bdbf5c1
+      eslint-plugin-flowtype: 5.2.0_eslint@7.16.0
+      eslint-plugin-import: 2.22.1_eslint@7.16.0
+      eslint-plugin-jest: 24.1.3_eslint@7.16.0
+      eslint-plugin-jsx-a11y: 6.4.1_eslint@7.16.0
+      eslint-plugin-react: 7.22.0_eslint@7.16.0
+      eslint-plugin-react-hooks: 4.2.0_eslint@7.16.0
+      eslint-plugin-testing-library: 3.10.1_eslint@7.16.0
       react: 17.0.1
       react-dom: 17.0.1_react@17.0.1
       react-scripts: 4.0.1
@@ -12157,16 +12195,26 @@ packages:
     dev: false
     name: '@rush-temp/my-app'
     resolution:
-      integrity: sha512-BWmBoikKQopx7QIb10AKRt2D+lxuNLxfRUOyjGLLoldm8UKXCDYMqN1FjGt6E8luiQa0Tqp+ml6MwcDxol3BDQ==
+      integrity: sha512-10uX2yk8V3Fek7+jB32yEClsZwXg2psdA6dXpuiddKVEstVNddS2x5cAo3LFUc1UhQbS9FzoAxEZ9bwzt4asTQ==
       tarball: 'file:projects/my-app.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@rush-temp/my-app': 'file:./projects/my-app.tgz'
   '@testing-library/jest-dom': ^5.11.8
   '@testing-library/react': ^11.2.2
   '@testing-library/user-event': ^12.6.0
+  '@typescript-eslint/eslint-plugin': ^4.0.0
+  '@typescript-eslint/parser': ^4.0.0
+  babel-eslint: ^10.0.0
   eslint: ^7.16.0
+  eslint-config-react-app: ^6.0.0
+  eslint-plugin-flowtype: ^5.2.0
+  eslint-plugin-import: ^2.22.0
+  eslint-plugin-jest: ^24.0.0
+  eslint-plugin-jsx-a11y: ^6.3.1
+  eslint-plugin-react: ^7.20.3
+  eslint-plugin-react-hooks: ^4.0.8
+  eslint-plugin-testing-library: ^3.9.0
   react: ^17.0.1
   react-dom: ^17.0.1
   react-scripts: 4.0.1


### PR DESCRIPTION
Fix errors printed by the ESLint extension for VS Code:

1. `my-app`'s **.eslintrc.json** said `"extends": ["react-app"]` which is an undeclared dependency  on the `eslint-config-react-app` package (called a "phantom dependency").  I replaced the **.eslintrc.json** shorthand with the fully qualified name to make this more obvious.
2. The installation model used by NPM and Yarn tolerates phantom dependencies (and even encourages this practice, referring to it as "hoisting").  Whereas phantom dependencies generally will not work with the installation models of PNPM, Rush, and Yarn-PNP -- this is a feature, not a bug: Phantom dependencies [cause confusing  problems](https://rushjs.io/pages/advanced/phantom_deps/) for nontrivial versioning relationships, as commonly arise in a large monorepo.  Thus we need to add `"eslint-config-react-app"` to your **package.json** file.
3. `eslint-config-react-app` has a bunch of peer dependencies on other ESLint packages.  They are declared as peers because of a [longstanding issue](https://www.npmjs.com/package/@rushstack/eslint-patch) where ESLint looks for dependencies in the `my-app` folder instead of in the `eslint-config-react-app` folder.
4. These peer dependencies need to be declared in your **my-app/package.json** file.  If you don't do that, it will work with NPM because of a [controversial](https://github.com/npm/rfcs/pull/43#issuecomment-522933566) behavior where NPM silently installs peer dependencies.  But it generally won't work with PNPM, Rush, or Yarn-PNP.  (In fact Rush and PNPM have a recommended setting [strictPeerDependencies](https://rushjs.io/pages/configs/rush_json/) that makes this an error rather than a warning.)

These issues all reflect that `create-react-app` is designed for starter projects and assumes that you are using NPM's installation model.
 